### PR TITLE
Remove flattener

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,8 @@
-const pipe = require('callbag-pipe');
 const map = require('callbag-map');
 const flatten = require('callbag-flatten');
 
-const switchmap = (mapper, flattener = ((_, result) => result)) => source => pipe(
-    source,
-    map(orig => pipe(
-            mapper(orig),
-            map(next => flattener(orig, next)),
-            )),
-    flatten,
-);
+const switchmap = mapper => source => flatten(map(mapper)(source))
+
 /*
 If I write the above without pipes, it'd be a bit impenetrable:
 ```js


### PR DESCRIPTION
If you agree on merging this, I'm going to fix README, tests etc - dont want to do that without knowing that this has a change to get merged in.

Reasoning:
1. IMHO `flattener` argument breaks Single Responsibility Principle, its functionality is **easily** (and more intuitively) done in user land by using `pipe(source, switchMap(mapper), map(flattener))` (or just writing an appropriate `mapper`) and I cant see a reason why this functionality should be embedded into `switchMap` itself
2. Rx has deprecated this - https://github.com/ReactiveX/rxjs/blob/5a6c90fa127a0f06e6fb5d13a1d22087e32ec15d/src/internal/operators/switchMap.ts#L14